### PR TITLE
Make sure the prefix option is a duplicate

### DIFF
--- a/lib/rack/gridfs.rb
+++ b/lib/rack/gridfs.rb
@@ -41,7 +41,7 @@ module Rack
     def normalize_options(options)
       options.tap do |opts|
         opts[:prefix] ||= "gridfs"
-        opts[:prefix].gsub!(/^\//, '')
+        opts[:prefix] = opts[:prefix].gsub(/^\//, '')
         opts[:mapper] ||= lambda { |path| %r!^/#{options[:prefix]}/(.+)!.match(path)[1] }
       end
     end

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -60,9 +60,11 @@ class ConfigTest < Test::Unit::TestCase
         assert_equal mware.instance_variable_get(:@options)[:prefix], 'gridfs'
       end
 
-      should "have a normalized prefix" do
-        mware = Rack::GridFS.new(nil, @options.merge({:prefix => '/myprefix'}))
+      should "have a normalized prefix without changing the original string" do
+        prefix_option = '/myprefix'
+        mware = Rack::GridFS.new(nil, @options.merge({:prefix => prefix_option}))
         assert_equal mware.instance_variable_get(:@options)[:prefix], 'myprefix'
+        assert_equal prefix_option, '/myprefix'
       end
 
       should "have a username option" do


### PR DESCRIPTION
Hello,

It is a pretty small change but since I encountered a bug recently because of this, I thought it would be worth making a pull request.

It just makes sure that any object normalized in the options is left intact.
So far this is only the `prefix` option.

Cheers,
mig
